### PR TITLE
Update ccfltr.c

### DIFF
--- a/ccfltr/ccfltr.c
+++ b/ccfltr/ccfltr.c
@@ -492,10 +492,6 @@ NTSTATUS ModifyStreamRead(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp, PVOID Con
             }
 #else
             try {
-                if (Irp->RequestorMode == UserMode) {
-                    ProbeForRead(pStreamHdr->Data, pStreamHdr->DataUsed, sizeof(BYTE));
-                }
-                
                 if (Irp->IoStatus.Status == STATUS_SUCCESS) {
                     RtlCopyMemory(lpStreamBuffer, pMdlBufferOut, pStreamHdr->DataUsed);
                     pDeviceExtension->DataUsed = pStreamHdr->DataUsed;


### PR DESCRIPTION
I'm not 100% sure about it, but I think that the `ProbeForRead` is incorrect. See my comment here (search for the post with "ProbeForRead" in the text):
https://www.osronline.com/showthread.cfm?link=288736

**Tim Roberts** confirmed that the call is not needed (except maybe for Windows 98 which I bet is not supported anyway).